### PR TITLE
1.0.2: minor fix to dx.api.project_archive

### DIFF
--- a/main.py
+++ b/main.py
@@ -984,7 +984,8 @@ def archiving_function(archive_pickle: dict, today: DateTime) -> None:
                 else:
                     logger.info(f'ARCHIVING {proj_id}')
                     if not DEBUG:
-                        res = dx.api.project_archive(proj_id)
+                        res = dx.api.project_archive(
+                            proj_id, input_params={'folder': '/'})
                         if res['count'] != 0:
                             temp_archived['archived'].append(
                                 f'{proj_name} ({proj_id})')
@@ -1035,7 +1036,8 @@ def archiving_function(archive_pickle: dict, today: DateTime) -> None:
                     else:
                         logger.info(f'ARCHIVING {proj_id}')
                         if not DEBUG:
-                            res = dx.api.project_archive(proj_id)
+                            res = dx.api.project_archive(
+                                proj_id, input_params={'folder': '/'})
                             if res['count'] != 0:
                                 temp_archived['archived'].append(
                                     f'{proj_name} (`{proj_id}`)')


### PR DESCRIPTION
# Changes
- added folder `/` to dx.api.project_archive as currently dx.api.project_archive(project-id) returns error:
`Expected input to have exactly one property in the set {files,folder}, code 422. Request Time=1658135770.9458177, Request ID=1658135771204-611384`. Used to work without either folder or files paramaters, but now it requires one of these apparently

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/automated-archiving/13)
<!-- Reviewable:end -->
