### PR TITLE
v1.0.4: Minor Fix for Archive

### DIFF
--- a/bin/slack.py
+++ b/bin/slack.py
@@ -143,7 +143,9 @@ class SlackClass:
         if self.debug:
             channel = "#egg-test"
 
-        logger.info(f"POST request to channel: {channel} with purpose {purpose}")
+        logger.info(
+            f"POST request to channel: {channel} with purpose {purpose}"
+        )
 
         strtoday = today.strftime("%d/%m/%Y")
 

--- a/bin/slack.py
+++ b/bin/slack.py
@@ -67,7 +67,7 @@ class SlackClass:
                 "in on any file within the directory_"
                 f"\n*Archive date: {archiving_date}*"
             ),
-            "speical-notify": (
+            "special-notify": (
                 f":warning: {today} "
                 "*Inactive project or directory to be archived*"
                 "\n_unless re-tag `no-archive`_"

--- a/bin/util.py
+++ b/bin/util.py
@@ -146,7 +146,9 @@ def remove_project_tag(project_id: str) -> None:
     """
 
     logger.info(f"REMOVE TAG: {project_id}")
-    dx.api.project_remove_tags(project_id, input_params={"tags": ["no-archive"]})
+    dx.api.project_remove_tags(
+        project_id, input_params={"tags": ["no-archive"]}
+    )
 
 
 def get_all_projects_in_dnanexus() -> Union[dict, dict]:
@@ -302,7 +304,9 @@ def get_all_directories(project_id: str) -> list:
     dx_project = dx.DXProject(project_id)
 
     # get all directories in root
-    all_directories_in_project = dx_project.list_folder(only="folders")["folders"]
+    all_directories_in_project = dx_project.list_folder(only="folders")[
+        "folders"
+    ]
 
     # filter out the /processed folder in root of staging-52
     directories_in_52 = [
@@ -314,7 +318,9 @@ def get_all_directories(project_id: str) -> list:
     # get all directories in /processed
     directories_in_52_processed = [
         (file.lstrip("/").lstrip("/processed"), file)
-        for file in dx_project.list_folder("/processed", only="folders")["folders"]
+        for file in dx_project.list_folder("/processed", only="folders")[
+            "folders"
+        ]
     ]
 
     return directories_in_52 + directories_in_52_processed
@@ -355,7 +361,9 @@ def directory_archive(
 
     # check for 'never-archive' tag in directory
     never_archive = list(
-        dx.find_data_objects(project=proj_id, folder=dir_path, tags=["never-archive"])
+        dx.find_data_objects(
+            project=proj_id, folder=dir_path, tags=["never-archive"]
+        )
     )
 
     if never_archive:
@@ -378,7 +386,9 @@ def directory_archive(
 
     # check for 'no-archive' tag in directory
     no_archive = list(
-        dx.find_data_objects(project=proj_id, folder=dir_path, tags=["no-archive"])
+        dx.find_data_objects(
+            project=proj_id, folder=dir_path, tags=["no-archive"]
+        )
     )
 
     if no_archive:
@@ -412,7 +422,9 @@ def directory_archive(
             # run archive on each of those file
             file_ids = [
                 file["id"]
-                for file in list(dx.find_data_objects(project=proj_id, folder=dir_path))
+                for file in list(
+                    dx.find_data_objects(project=proj_id, folder=dir_path)
+                )
             ]
 
             archived_file_count = 0
@@ -611,7 +623,9 @@ def find_projs_and_notify(
         if check_directory(trimmed_directory, month2)
     ]
 
-    logger.info(f"No. of old enough directories: {len(old_enough_directories)}")
+    logger.info(
+        f"No. of old enough directories: {len(old_enough_directories)}"
+    )
 
     if old_enough_projects_dict:
         logger.info("Processing project")
@@ -636,7 +650,9 @@ def find_projs_and_notify(
                         describe={"fields": {"archivalState": True}},
                     )
                 )
-                status = set([x["describe"]["archivalState"] for x in all_files])
+                status = set(
+                    [x["describe"]["archivalState"] for x in all_files]
+                )
 
             if "live" in status:
                 # there is something to be archived
@@ -753,7 +769,9 @@ def find_projs_and_notify(
                                         "project": project_52,
                                     },
                                 )
-                        special_notify_list.append(f"{original_dir} in `staging52`")
+                        special_notify_list.append(
+                            f"{original_dir} in `staging52`"
+                        )
                         archive_pickle["staging_52"].append(original_dir)
                         to_be_archived_dir.append(
                             f"<{STAGING_PREFIX}/{trimmed_dir}|{original_dir}>"
@@ -853,13 +871,19 @@ def tagging_function(debug: bool) -> None:
             if "partial archived" in tags:
                 dx.api.project_remove_tags(
                     k,
-                    input_params={"tags": ["partial archived", "fully archived"]},
+                    input_params={
+                        "tags": ["partial archived", "fully archived"]
+                    },
                 )
-                dx.api.project_add_tags(k, input_params={"tags": ["fully archived"]})
+                dx.api.project_add_tags(
+                    k, input_params={"tags": ["fully archived"]}
+                )
             elif "fully archived" in tags:
                 continue
             else:
-                dx.api.project_add_tags(k, input_params={"tags": ["fully archived"]})
+                dx.api.project_add_tags(
+                    k, input_params={"tags": ["fully archived"]}
+                )
 
     # whatever is leftover from above projects, we do the query
     # they can be 'live' or 'partially archived'
@@ -887,7 +911,9 @@ def tagging_function(debug: bool) -> None:
                     # we do a reset and add 'partial'
                     dx.api.project_remove_tags(
                         k,
-                        input_params={"tags": ["partial archived", "fully archived"]},
+                        input_params={
+                            "tags": ["partial archived", "fully archived"]
+                        },
                     )
                     dx.api.project_add_tags(
                         k, input_params={"tags": ["partial archived"]}
@@ -905,7 +931,9 @@ def tagging_function(debug: bool) -> None:
                 if "partial archived" in tags:
                     dx.api.project_remove_tags(
                         k,
-                        input_params={"tags": ["partial archived", "fully archived"]},
+                        input_params={
+                            "tags": ["partial archived", "fully archived"]
+                        },
                     )
                     dx.api.project_add_tags(
                         k, input_params={"tags": ["fully archived"]}
@@ -1096,15 +1124,20 @@ def archiving_function(
 
                             for file_id in file_ids:
                                 try:
-                                    dx.DXFile(file_id, project=proj_id).archive()
+                                    dx.DXFile(
+                                        file_id, project=proj_id
+                                    ).archive()
                                     archived_file_count += 1
                                 except Exception as e:
                                     logger.error(e)
-                                    failed_archive.append(f"{proj_id}:{file_id}")
+                                    failed_archive.append(
+                                        f"{proj_id}:{file_id}"
+                                    )
 
                             if archived_file_count > 0:
                                 temp_archived["archived"].append(
-                                    f"{proj_name} {proj_id} " f"{archived_file_count}"
+                                    f"{proj_name} {proj_id} "
+                                    f"{archived_file_count}"
                                 )
             else:
                 # project not older than ARCHIVE_MODIFIED_MONTH
@@ -1243,7 +1276,9 @@ def get_old_tar_and_notify(
         dx.find_data_objects(
             name="^run.*.tar.gz",
             name_mode="regexp",
-            describe={"fields": {"modified": True, "folder": True, "name": True}},
+            describe={
+                "fields": {"modified": True, "folder": True, "name": True}
+            },
             project=project_52,
         )
     )
@@ -1258,7 +1293,10 @@ def get_old_tar_and_notify(
         for x in filtered_result
     ]
 
-    dates = [make_datetime_format(d["describe"]["modified"]) for d in filtered_result]
+    dates = [
+        make_datetime_format(d["describe"]["modified"])
+        for d in filtered_result
+    ]
 
     # earliest date among the list of tars
     min_date = min(dates).strftime("%Y-%m-%d")

--- a/bin/util.py
+++ b/bin/util.py
@@ -971,10 +971,18 @@ def archiving_function(
     if list_of_projects_in_memory:
         # loop through each project
         for proj_id in list_of_projects_in_memory:
-            project = dx.DXProject(proj_id)
+            try:
+                project = dx.DXProject(proj_id)
 
-            # query latest project detail on archiving time
-            detail = project.describe()
+                # query latest project detail on archiving time
+                detail = project.describe()
+            except dx.exceptions.ResourceNotFound as e:
+                # if project-id no longer exist on DNAnexus
+                # probably project got deleted or etc.
+                # causing this part to fail
+                logger.info(f"{proj_id} seems to have been deleted" f"{e}")
+                continue
+
             proj_name = detail["name"]
             modified_epoch = detail["modified"]
             tags = detail["tags"]
@@ -1218,10 +1226,10 @@ def get_old_tar_and_notify(
 ) -> None:
     """
     Function to get tar which are not modified in the last 3 months
-    
+
     Regex Format:
         only returns "run.....tar.gz" in staging52
-    
+
     :param: today: date for Slack notification
     :param: tar_month: N month of inactivity for tar.gz
         before getting picked up

--- a/main.py
+++ b/main.py
@@ -44,14 +44,20 @@ if __name__ == "__main__":
         DNANEXUS_TOKEN = os.environ["DNANEXUS_TOKEN"]
 
         # project-ids
-        PROJECT_52 = os.environ.get("PROJECT_52", "project-FpVG0G84X7kzq58g19vF1YJQ")
-        PROJECT_53 = os.environ.get("PROJECT_53", "project-FvbzbX84gG9Z3968BJjxYZ1k")
+        PROJECT_52 = os.environ.get(
+            "PROJECT_52", "project-FpVG0G84X7kzq58g19vF1YJQ"
+        )
+        PROJECT_53 = os.environ.get(
+            "PROJECT_53", "project-FvbzbX84gG9Z3968BJjxYZ1k"
+        )
 
         # number data envs
         MONTH2 = int(os.environ.get("AUTOMATED_MONTH_002", 6))
         MONTH3 = int(os.environ.get("AUTOMATED_MONTH_003", 3))
         TAR_MONTH = int(os.environ.get("TAR_MONTH", 3))
-        ARCHIVE_MODIFIED_MONTH = int(os.environ.get("ARCHIVE_MODIFIED_MONTH", 1))
+        ARCHIVE_MODIFIED_MONTH = int(
+            os.environ.get("ARCHIVE_MODIFIED_MONTH", 1)
+        )
 
         # file pathway envs
         ARCHIVE_PICKLE_PATH = os.environ.get(


### PR DESCRIPTION
# Changes
- archive fail sometimes when project has been deleted before the archiving start and dx.DXProject(project-id) returns a None
- minor spelling error in slack.py
- line length 79 reformat

# Solution
- add a try clause and if dx.exceptions.ResourceNotFound: skip

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/automated-archiving/24)
<!-- Reviewable:end -->
