### PR TITLE
Adding precision projects archiving

### DIFF
--- a/bin/slack.py
+++ b/bin/slack.py
@@ -71,19 +71,19 @@ class SlackClass:
 
         msgs: dict[str, str] = {
             "002": (
-                f":bangbang: {today} *002 projects to be archived:*"
+                f":redalert: {today} *002 projects to be archived:*"
                 "\n_Please tag `no-archive` or `never-archive` "
                 "in project.Settings.Tags_"
                 f"\n*Archive date: {archiving_date}*"
             ),
             "003": (
-                f":bangbang: {today} *003 projects to be archived:*"
+                f":redalert: {today} *003 projects to be archived:*"
                 "\n_Please tag `no-archive` or `never-archive` "
                 "in project.Settings.Tags_"
                 f"\n*Archive date: {archiving_date}*"
             ),
             "staging52": (
-                f":bangbang: {today} "
+                f":redalert: {today} "
                 "*Directories in `staging52` to be archived:*"
                 "\n_Please tag `no-archive` or `never-archive` "
                 "in on any file within the directory_"
@@ -121,9 +121,14 @@ class SlackClass:
                 f" {tar_period_end_date}\n_Please find complete list of"
                 " file-id below:_"
             ),
+            "precision": (
+                ":redalert: automated-archiving: "
+                f"Folders to be archived in `precision` projects"
+                f"\n*Archive date: {archiving_date}*"
+            ),
         }
 
-        return msgs[purpose]
+        return msgs.get(purpose, "No message found")
 
     def post_message_to_slack(
         self,
@@ -159,7 +164,7 @@ class SlackClass:
         """
 
         if self.debug:
-            channel: str = "#egg-test"
+            channel: str = "U02HPRQ9X7Z"
 
         logger.info(
             f"POST request to channel: {channel} with purpose {purpose}",

--- a/bin/util.py
+++ b/bin/util.py
@@ -37,7 +37,7 @@ def read_or_new_pickle(path: str) -> dict:
     return pickle_dict
 
 
-def _older_than(month: int, modified_epoch: int) -> bool:
+def older_than(month: int, modified_epoch: int) -> bool:
     """
     Determine if a modified epoch date is older than X month
 
@@ -50,10 +50,26 @@ def _older_than(month: int, modified_epoch: int) -> bool:
         - `False` if have been modified in last X month
     """
 
-    modified = modified_epoch / 1000.0
-    date = dt.datetime.fromtimestamp(modified)
+    return (
+        _make_datetime_format(modified_epoch) + relativedelta(months=+month)
+        < dt.datetime.today()
+    )
 
-    return date + relativedelta(months=+month) < dt.datetime.today()
+
+def write_to_pickle(path: str, pickle_dict: dict) -> None:
+    """
+    Write to memory pickle
+
+    Parameters:
+    :param: path: directory path to pickle
+    :param: pickle_dict: `dict` to write into pickle
+
+    Returns:
+        `None`
+    """
+    logger.info(f"Writing into pickle file at: {path}")
+    with open(path, "wb") as f:
+        pickle.dump(pickle_dict, f)
 
 
 def dx_login(today: dt.datetime, token: str, slack: SlackClass) -> None:
@@ -350,7 +366,7 @@ def get_old_tar_and_notify(
 
     # list of tar files not modified in the last 3 months
     filtered_result = [
-        x for x in result if _older_than(tar_month, x["describe"]["modified"])
+        x for x in result if older_than(tar_month, x["describe"]["modified"])
     ]
 
     if not filtered_result:


### PR DESCRIPTION
# Changes
- to archive project-id listed in `PRECISION_ARCHIVING` folder-by-folder rather than the whole project altogether.
- `find_projects` function now return list of key (project) and value (list of project-id for archiving)
- `notify_on_slack` function to do the Slack notification for both 002 projects etc and precision projects
- `write_to_file` function to write archived file-id or any file-id that failed archiving to an actual txt file (for record purpose)

# Script Workflow
If day is 1st or 15th of the month, check if there's any to-be-archived project-id in its memory (pickle). If there are, run archiving function for normal projects and precision projects. Then, run find projects for normal projects and precision projects to find projects that are both unarchived and fit the criteria for archiving. Send those projects-id on Slack. Write those project into a pickle (memory). 