### PR TITLE
IN-535: Guideline

### DIFF
--- a/bin/environment.py
+++ b/bin/environment.py
@@ -27,6 +27,7 @@ class EnvironmentVariableClass:
         self.AUTOMATED_REGEX_EXCLUDE: list[str]
         self.PRECISION_ARCHIVING: list[str]
         self.DNANEXUS_URL_PREFIX: str
+        self.GUIDELINE_URL: str
 
         self.required_variables = {
             "SLACK_TOKEN": None,
@@ -43,6 +44,7 @@ class EnvironmentVariableClass:
             "AUTOMATED_REGEX_EXCLUDE": None,
             "PRECISION_ARCHIVING": None,
             "DNANEXUS_URL_PREFIX": "https://platform.dnanexus.com/panx/projects",
+            "GUIDELINE_URL": "https://cuhbioinformatics.atlassian.net/l/cp/Uh8PmK0T"
         }
 
     def load_configs(self):

--- a/bin/environment.py
+++ b/bin/environment.py
@@ -44,7 +44,7 @@ class EnvironmentVariableClass:
             "AUTOMATED_REGEX_EXCLUDE": None,
             "PRECISION_ARCHIVING": None,
             "DNANEXUS_URL_PREFIX": "https://platform.dnanexus.com/panx/projects",
-            "GUIDELINE_URL": "https://cuhbioinformatics.atlassian.net/l/cp/Uh8PmK0T"
+            "GUIDELINE_URL": "https://cuhbioinformatics.atlassian.net/l/cp/Uh8PmK0T",
         }
 
     def load_configs(self):

--- a/bin/slack.py
+++ b/bin/slack.py
@@ -257,6 +257,7 @@ class SlackClass:
         Parameters:
         :param: aim_to_data: `dict` with aim as key and data as value
         """
+
         for aim, data in aim_to_data.items():
             if aim == "tars":
                 self._send_message_with_attachment(

--- a/main.py
+++ b/main.py
@@ -92,6 +92,11 @@ def main():
 
     find.save_to_pickle()
 
+    slack.post_simple_message_to_slack(
+            "#egg-alerts",
+            f"automated-archiving guideline: {env.GUIDELINE_URL}",
+        )
+
     slack.notify(
         {
             "projects2": find.archiving_projects_2_slack,

--- a/main.py
+++ b/main.py
@@ -93,9 +93,9 @@ def main():
     find.save_to_pickle()
 
     slack.post_simple_message_to_slack(
-            "#egg-alerts",
-            f"automated-archiving guideline: {env.GUIDELINE_URL}",
-        )
+        "#egg-alerts",
+        f"automated-archiving guideline: {env.GUIDELINE_URL}",
+    )
 
     slack.notify(
         {


### PR DESCRIPTION
# Change
- Slack will send guideline url before archiving notification
- new env `GUIDELINE_URL`
<img width="764" alt="Screenshot 2024-04-17 at 11 24 13" src="https://github.com/eastgenomics/automated-archiving/assets/60819172/d8004710-4fac-47f2-9bff-ed3f8647f199">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/automated-archiving/41)
<!-- Reviewable:end -->
